### PR TITLE
Fix Prompt Guard result not being set properly in the UI

### DIFF
--- a/src/app/features/ChatWindow/index.tsx
+++ b/src/app/features/ChatWindow/index.tsx
@@ -129,7 +129,7 @@ const ChatWindow = () => {
         const pgMsg: ChatMessage = {
           hash: hashCode(JSON.stringify(promptResp)),
           type: "prompt_guard",
-          output: JSON.stringify(promptResp),
+          output: JSON.stringify(promptResp?.result),
         };
         setMessages((prevMessages) => [...prevMessages, pgMsg]);
 


### PR DESCRIPTION
Port of a patch by @snpranav to fix "Benign" being displayed even when Prompt Guard did detect something.