### PR TITLE
Send entire LLM input to AI Guard 

### DIFF
--- a/src/app/api/docs/route.ts
+++ b/src/app/api/docs/route.ts
@@ -1,0 +1,83 @@
+import type { NextRequest } from "next/server";
+import { BedrockEmbeddings } from "@langchain/aws";
+import { MemoryVectorStore } from "langchain/vectorstores/memory";
+import type { AuthZ } from "pangea-node-sdk";
+
+import type { PangeaResponse } from "@src/types";
+import { GoogleDriveRetriever } from "@src/google";
+
+import { authzCheckRequest, validateToken } from "../requests";
+
+const docsLoader = new GoogleDriveRetriever({
+  credentials: JSON.parse(process.env.GOOGLE_DRIVE_CREDENTIALS!),
+  folderId: process.env.GOOGLE_DRIVE_FOLDER_ID!,
+  scopes: ["https://www.googleapis.com/auth/drive.readonly"],
+});
+
+const embeddingsModel = new BedrockEmbeddings({
+  region: process.env.PANGEA_AI_REGION!,
+  credentials: {
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+  },
+});
+
+export interface RequestBody {
+  /** Whether or not to apply AuthZ. */
+  authz: boolean;
+
+  /** User's prompt. */
+  userPrompt: string;
+}
+
+export async function POST(request: NextRequest) {
+  const { success, username } = await validateToken(request);
+
+  if (!(success && username)) {
+    return new Response("Forbidden", { status: 403 });
+  }
+
+  const body: RequestBody = await request.json();
+
+  const vectorStore = await MemoryVectorStore.fromDocuments(
+    await docsLoader.invoke(""), // Load all documents.
+    embeddingsModel,
+  );
+  const retriever = vectorStore.asRetriever();
+  let docs = await retriever.invoke(body.userPrompt);
+
+  // Filter documents based on user's permissions in AuthZ.
+  const authzResponses: PangeaResponse<AuthZ.CheckResult>[] = [];
+  if (body.authz) {
+    docs = await Promise.all(
+      docs.map(async (doc) => {
+        const response = await authzCheckRequest({
+          subject: { type: "user", id: username },
+          action: "read",
+          resource: { type: "file", id: doc.id },
+          debug: true,
+        });
+        if ("request_id" in response) {
+          authzResponses.push({
+            request_id: response.request_id,
+            request_time: response.request_time,
+            response_time: response.response_time,
+            result: response.result,
+            status: response.status,
+            summary: response.summary,
+          });
+        }
+        return response.result.allowed ? doc : null;
+      }),
+    ).then((results) => results.filter((doc) => doc !== null));
+  }
+
+  return Response.json({
+    authzResponses,
+    documents: docs.map(({ id, metadata, pageContent }) => ({
+      id,
+      metadata,
+      pageContent,
+    })),
+  });
+}

--- a/src/app/features/ChatWindow/utils.ts
+++ b/src/app/features/ChatWindow/utils.ts
@@ -1,20 +1,31 @@
+import type { MessageFieldWithRole } from "@langchain/core/messages";
+
 import {
   aiProxyRequest,
   auditProxyRequest,
   dataGuardProxyRequest,
+  docsProxyRequest,
   promptGuardProxyRequest,
 } from "@src/app/proxy";
 
-export const sendUserMessage = async (
+export const fetchDocuments = async (
   token: string,
-  message: string,
-  system: string,
+  userPrompt: string,
   authz = false,
 ) => {
+  return await docsProxyRequest(token, { userPrompt, authz });
+};
+
+export const generateCompletions = async (
+  token: string,
+  messages: MessageFieldWithRole[],
+  systemPrompt: string,
+  userPrompt: string,
+) => {
   return await aiProxyRequest(token, {
-    authz,
-    userPrompt: message,
-    systemPrompt: system,
+    input: messages,
+    systemPrompt,
+    userPrompt,
   });
 };
 
@@ -37,10 +48,13 @@ export const callPromptGuard = async (
   return await promptGuardProxyRequest(token, { messages });
 };
 
-export const callInputDataGuard = async (token: string, userPrompt: string) => {
+export const callInputDataGuard = async (
+  token: string,
+  messages: readonly MessageFieldWithRole[],
+) => {
   const payload = {
-    recipe: "pangea_prompt_guard",
-    text: userPrompt,
+    recipe: "pangea_llm_prompt_guard",
+    messages,
   };
 
   return await dataGuardProxyRequest(token, payload);

--- a/src/app/proxy.ts
+++ b/src/app/proxy.ts
@@ -1,11 +1,24 @@
 import type { DocumentInterface } from "@langchain/core/documents";
 import type { AuthZ, PromptGuard } from "pangea-node-sdk";
 
+import type { RequestBody as AiRequestBody } from "@src/app/api/ai/route";
+import type { RequestBody as AiGuardRequestBody } from "@src/app/api/data/route";
+import type { RequestBody as DocsRequestBody } from "@src/app/api/docs/route";
 import type { AIGuardResult, PangeaResponse } from "@src/types";
+
+export const docsProxyRequest = async (
+  token: string,
+  body: DocsRequestBody,
+): Promise<{
+  authzResponses: PangeaResponse<AuthZ.CheckResult>[];
+  documents: DocumentInterface[];
+}> => {
+  return baseProxyRequest(token, "docs", "", body);
+};
 
 export const dataGuardProxyRequest = async (
   token: string,
-  body: unknown,
+  body: AiGuardRequestBody,
 ): Promise<PangeaResponse<AIGuardResult>> => {
   return baseProxyRequest(token, "data", "", body);
 };
@@ -27,12 +40,8 @@ export const auditProxyRequest = async (
 
 export const aiProxyRequest = async (
   token: string,
-  body: unknown,
-): Promise<{
-  content: string;
-  authzResponses: PangeaResponse<AuthZ.CheckResult>[];
-  documents: DocumentInterface[];
-}> => {
+  body: AiRequestBody,
+): Promise<{ content: string }> => {
   return baseProxyRequest(token, "ai", "", body);
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { MessageFieldWithRole } from "@langchain/core/messages";
+
 export interface PangeaResponse<T = unknown> {
   request_id: string;
   request_time: string;
@@ -25,4 +27,5 @@ export interface AIGuardResult {
     }>;
   };
   prompt_text: string;
+  prompt_messages: MessageFieldWithRole[];
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,7 @@
+import type { DocumentInterface } from "@langchain/core/documents";
+import type { MessageFieldWithRole } from "@langchain/core/messages";
+import type { Profile } from "@pangeacyber/react-auth";
+
 export const delay = (time: number) => {
   return new Promise((resolve) => setTimeout(resolve, time));
 };
@@ -14,4 +18,36 @@ export const rateLimitQuery = () => {
   };
 
   return limitSearch;
+};
+
+export const constructLlmInput = ({
+  systemPrompt,
+  userPrompt,
+  documents,
+  profile,
+}: {
+  systemPrompt: string;
+  userPrompt: string;
+  documents: readonly DocumentInterface[];
+  profile: Profile;
+}): MessageFieldWithRole[] => {
+  const context = documents.length
+    ? `PTO balances:\n${documents
+        .map(({ pageContent }) => pageContent)
+        .join("\n\n")})`
+    : "";
+
+  return [
+    {
+      role: "system",
+      content: `${systemPrompt}
+User's first name: ${profile.first_name}
+User's last name: ${profile.last_name}
+Context: ${context}`,
+    },
+    {
+      role: "user",
+      content: userPrompt,
+    },
+  ];
 };


### PR DESCRIPTION
Previously we were only sending the user's prompt to AI Guard, and indeed this was fine when we were only interested in demoing the guards on malicious or sensitive user input. However, the next demos want to craft attacks that involve the system prompt and the RAG documents, so AI Guard needs to cover everything that's going to the LLM.

The easiest way to accomplish this would be to run AI Guard in `POST /api/ai` before sending the input to the LLM, and this is probably how it would be done in a real world application. However, this chat app runs the AI Guard check as a separate step with its own API endpoint because we want to keep it toggleable with its own processing step and loading indicator for demonstration purposes. So to accommodate this, a slightly bigger refactor is done:

1. Document fetching is now done in a new endpoint in order to have the documents earlier than chat completions generation time.
2. When an input is submitted, the documents are fetched and the system prompt, user prompt, and documents are all collected and sent to AI Guard.
3. Guarded input is sent to `POST /api/ai`.

---

Based off of #39, will un-draft this once that one is merged.