### PR TITLE
Add FPE unredaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ services.
 - Node.js v20 or v22.
 - yarn v4.5.1 (or greater).
 - A [Pangea account][Pangea signup] with AI Guard, Prompt Guard, AuthN, AuthZ,
-  and Secure Audit Log enabled.
+  Redact, and Secure Audit Log enabled.
 - A Google Drive folder containing spreadsheets.
 
   - Note down the ID of the folder for later (see [the LangChain docs][retrieve-the-google-docs]

--- a/src/app/api/unredact/route.ts
+++ b/src/app/api/unredact/route.ts
@@ -1,0 +1,41 @@
+import type { NextRequest } from "next/server";
+
+import type { PangeaResponse, UnredactResult } from "@src/types";
+
+import { getUrl, postRequest, validateToken } from "../requests";
+
+const SERVICE_NAME = "redact";
+const API_VERSION = "v1";
+
+export interface RequestBody {
+  /** Data to unredact */
+  redacted_data: string;
+
+  /** FPE context used to decrypt and unredact data */
+  fpe_context: string;
+}
+
+export async function POST(request: NextRequest) {
+  const { success: authenticated, username } = await validateToken(request);
+
+  if (!(authenticated && username)) {
+    return new Response("Forbidden", { status: 403 });
+  }
+
+  const body: RequestBody = await request.json();
+
+  const endpoint = `${API_VERSION}/unredact`;
+  const url = getUrl(SERVICE_NAME, endpoint);
+
+  const {
+    success,
+    response,
+  }: { success: boolean; response: PangeaResponse<UnredactResult> } =
+    await postRequest(url, body);
+
+  if (!success) {
+    return new Response("Failed to unredact data", { status: 500 });
+  }
+
+  return Response.json(response);
+}

--- a/src/app/features/ChatWindow/index.tsx
+++ b/src/app/features/ChatWindow/index.tsx
@@ -36,6 +36,7 @@ import {
   callResponseDataGuard,
   fetchDocuments,
   generateCompletions,
+  unredact,
 } from "./utils";
 
 function hashCode(str: string) {
@@ -232,6 +233,16 @@ const ChatWindow = () => {
     } catch (err) {
       const status = err instanceof Response ? err.status : 0;
       processingError("AI Guard call failed, please try again", status);
+    }
+
+    // Unredact if a FPE context was returned.
+    if (guardedInput.result.fpe_context) {
+      const unredacted = await unredact(
+        token,
+        llmResponse,
+        guardedInput.result.fpe_context,
+      );
+      llmResponse = unredacted.result.data;
     }
 
     const llmMsg: ChatMessage = {

--- a/src/app/features/ChatWindow/utils.ts
+++ b/src/app/features/ChatWindow/utils.ts
@@ -5,6 +5,7 @@ import {
   auditProxyRequest,
   dataGuardProxyRequest,
   docsProxyRequest,
+  unredactProxyRequest,
 } from "@src/app/proxy";
 import type { DetectorOverrides } from "@src/types";
 
@@ -55,6 +56,19 @@ export const callResponseDataGuard = async (
   };
 
   return await dataGuardProxyRequest(token, payload);
+};
+
+export const unredact = async (
+  token: string,
+  redacted: string,
+  fpe_context: string,
+) => {
+  const payload = {
+    redacted_data: redacted,
+    fpe_context,
+  };
+
+  return await unredactProxyRequest(token, payload);
 };
 
 export const auditUserPrompt = async (

--- a/src/app/proxy.ts
+++ b/src/app/proxy.ts
@@ -4,7 +4,8 @@ import type { AuthZ } from "pangea-node-sdk";
 import type { RequestBody as AiRequestBody } from "@src/app/api/ai/route";
 import type { RequestBody as AiGuardRequestBody } from "@src/app/api/data/route";
 import type { RequestBody as DocsRequestBody } from "@src/app/api/docs/route";
-import type { AIGuardResult, PangeaResponse } from "@src/types";
+import type { RequestBody as UnredactRequestBody } from "@src/app/api/unredact/route";
+import type { AIGuardResult, PangeaResponse, UnredactResult } from "@src/types";
 
 export const docsProxyRequest = async (
   token: string,
@@ -21,6 +22,13 @@ export const dataGuardProxyRequest = async (
   body: AiGuardRequestBody,
 ): Promise<PangeaResponse<AIGuardResult>> => {
   return baseProxyRequest(token, "data", "", body);
+};
+
+export const unredactProxyRequest = async (
+  token: string,
+  body: UnredactRequestBody,
+): Promise<PangeaResponse<UnredactResult>> => {
+  return baseProxyRequest(token, "unredact", "", body);
 };
 
 export const auditProxyRequest = async (

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ export interface AIGuardResult {
   prompt_text: string;
   prompt_messages: MessageFieldWithRole[];
   blocked: boolean;
+  fpe_context?: string;
 }
 
 export interface Detector {
@@ -49,4 +50,8 @@ export interface DetectorOverrides {
   };
   pii_entity: { disabled?: boolean };
   secrets_detection: { disabled?: boolean };
+}
+
+export interface UnredactResult {
+  data: string;
 }


### PR DESCRIPTION
LLM responses are now unredacted (after the response guard) if a FPE context was returned by the input guard.

In this example, note how the input PII isn't what was sent to the LLM. After the response is guarded, the values are unredacted to the original PII present in the user input.

![2025-02-13-14-30-14](https://github.com/user-attachments/assets/2f2d28f1-592f-43cc-b08a-27519d82912a)
